### PR TITLE
Allow users to reset-password via request.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -15,14 +15,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Flashcards"
-        tools:targetApi="31" >
+        tools:targetApi="31">
         <activity
-            android:name=".ForgotPasswordActivity"
+            android:name=".ResetPasswordActivity"
             android:exported="true"
             android:theme="@style/Theme.Flashcards">
             <intent-filter
                 android:autoVerify="true"
-                tools:ignore="AppLinkUrlError" >
+                tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -30,14 +30,15 @@
 
                 <data
                     android:host="supabase.com"
-                    android:scheme="reset" />
+                    android:path="/reset-callback"
+                    android:scheme="app" />
             </intent-filter>
 
         </activity>
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Flashcards" >
+            android:theme="@style/Theme.Flashcards">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -47,10 +48,10 @@
         <activity
             android:name=".DeepLinkerActivity"
             android:exported="true"
-            android:theme="@style/Theme.Flashcards" >
+            android:theme="@style/Theme.Flashcards">
             <intent-filter
                 android:autoVerify="true"
-                tools:ignore="AppLinkUrlError" >
+                tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -58,6 +59,7 @@
 
                 <data
                     android:host="supabase.com"
+                    android:path="/auth-callback"
                     android:scheme="app" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/belmontCrest/cardCrafter/DeepLinkerActivity.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/DeepLinkerActivity.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.belmontCrest.cardCrafter.model.application.AppViewModelProvider
 import com.belmontCrest.cardCrafter.model.uiModels.PreferencesManager
@@ -29,6 +28,7 @@ import com.belmontCrest.cardCrafter.supabase.controller.viewModels.DeepLinksView
 import com.belmontCrest.cardCrafter.ui.theme.ColorSchemeClass
 import com.belmontCrest.cardCrafter.ui.theme.FlashcardsTheme
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
+import com.belmontCrest.cardCrafter.ui.theme.boxViewsModifier
 import com.belmontCrest.cardCrafter.uiFunctions.SubmitButton
 import kotlinx.coroutines.launch
 import kotlin.getValue
@@ -82,12 +82,13 @@ class DeepLinkerActivity : ComponentActivity() {
                 dynamicColor = preferences.customScheme.value,
                 cuteTheme = preferences.cuteTheme.value
             ) {
-                Surface(
+                Scaffold(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
+                ) { padding ->
                     SignInSuccessScreen(
-                        modifier = Modifier.padding(20.dp),
+                        modifier = Modifier
+                            .boxViewsModifier(getUIStyle.getColorScheme())
+                            .padding(padding),
                         getUIStyle = getUIStyle,
                         email = emailState.value,
                         createdAt = createdAtState.value,

--- a/app/src/main/java/com/belmontCrest/cardCrafter/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/ResetPasswordActivity.kt
@@ -8,13 +8,14 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.lifecycleScope
@@ -33,6 +35,7 @@ import com.belmontCrest.cardCrafter.ui.theme.ColorSchemeClass
 import com.belmontCrest.cardCrafter.ui.theme.FlashcardsTheme
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.scrollableBoxViewModifier
+import com.belmontCrest.cardCrafter.uiFunctions.CustomText
 import com.belmontCrest.cardCrafter.uiFunctions.PasswordTextField
 import com.belmontCrest.cardCrafter.uiFunctions.SubmitButton
 import com.belmontCrest.cardCrafter.uiFunctions.showToastMessage
@@ -40,7 +43,7 @@ import kotlinx.coroutines.launch
 import kotlin.getValue
 
 @RequiresApi(Build.VERSION_CODES.Q)
-class ForgotPasswordActivity : ComponentActivity() {
+class ResetPasswordActivity : ComponentActivity() {
 
     private lateinit var preferences: PreferencesManager
     private lateinit var callback: (String, String) -> Unit
@@ -50,12 +53,7 @@ class ForgotPasswordActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        lifecycleScope.launch {
-            deepLinksVM.deepLinker(
-                intent, callback = { email, createdAt ->
-                    callback(email, createdAt.toString())
-                })
-        }
+        handleDeepLink(intent)
         enableEdgeToEdge()
         setContent {
             val emailState = remember { mutableStateOf("") }
@@ -86,16 +84,19 @@ class ForgotPasswordActivity : ComponentActivity() {
                 dynamicColor = preferences.customScheme.value,
                 cuteTheme = preferences.cuteTheme.value
             ) {
-                Surface(
+                Scaffold(
                     modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
+                ) { padding ->
                     Column(
-                        modifier = Modifier.scrollableBoxViewModifier(
-                            rememberScrollState(), getUIStyle.getColorScheme()
-                        )
+                        modifier = Modifier
+                            .scrollableBoxViewModifier(
+                                rememberScrollState(), getUIStyle.getColorScheme()
+                            )
+                            .padding(padding),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        Text("Reset password")
+                        CustomText("Reset password", getUIStyle)
                         PasswordTextField(
                             label = "New Password", password = password,
                             onPasswordChange = { password = it },
@@ -139,6 +140,19 @@ class ForgotPasswordActivity : ComponentActivity() {
                         }, enabled, getUIStyle, "Reset", Modifier.fillMaxWidth())
                     }
                 }
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleDeepLink(intent)
+    }
+
+    private fun handleDeepLink(intent: Intent) {
+        lifecycleScope.launch {
+            deepLinksVM.deepLinker(intent) { email, createdAt ->
+                callback(email, createdAt.toString())
             }
         }
     }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardUpdaterHandler.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardUpdaterHandler.kt
@@ -106,14 +106,12 @@ suspend fun updateDecksCardList(
     return cardDeckViewModel.updateCards(deck)
 }
 
-fun returnSavedCard(card: Card) : SavedCard {
-    return SavedCard(
-        id = card.id,
-        reviewsLeft = card.reviewsLeft,
-        nextReview = card.nextReview,
-        prevSuccess = card.prevSuccess,
-        passes = card.passes,
-        totalPasses = card.totalPasses,
-        partOfList = card.partOfList
-    )
-}
+fun Card.toSavedCard(): SavedCard = SavedCard(
+    id = this.id,
+    reviewsLeft = this.reviewsLeft,
+    nextReview = this.nextReview,
+    prevSuccess = this.prevSuccess,
+    passes = this.passes,
+    totalPasses = this.totalPasses,
+    partOfList = this.partOfList
+)

--- a/app/src/main/java/com/belmontCrest/cardCrafter/model/InsertDaoHelper.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/model/InsertDaoHelper.kt
@@ -9,6 +9,15 @@ import com.belmontCrest.cardCrafter.localDatabase.tables.HintCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.MultiChoiceCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.ThreeFieldCard
+import com.belmontCrest.cardCrafter.model.Type.BASIC
+import com.belmontCrest.cardCrafter.model.Type.HINT
+import com.belmontCrest.cardCrafter.model.Type.MULTI
+import com.belmontCrest.cardCrafter.model.Type.NOTATION
+import com.belmontCrest.cardCrafter.model.Type.THREE
+import com.belmontCrest.cardCrafter.supabase.model.tables.SBDeckDto
+import com.belmontCrest.cardCrafter.supabase.model.tables.SealedCTToImport
+import com.belmontCrest.cardCrafter.supabase.model.tables.toCard
+import java.util.Date
 
 
 @Dao
@@ -51,4 +60,105 @@ interface InsertOrAbortDao {
 
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertThreeCard(threeFieldCard: ThreeFieldCard): Long
+}
+
+@Dao
+interface TransactionCT : InsertAndReplaceDao {
+    suspend fun insertTransactionCT(
+        ct: SealedCTToImport, deckId: Int, sbDeckDto: SBDeckDto, reviewAmount: Int
+    ) {
+        val cardIdentifier = ct.toCard().cardIdentifier
+        val deckCardNumber = cardIdentifier.substringAfterLast("-").toInt()
+        when (ct) {
+            is SealedCTToImport.Basic -> {
+                val cardId = returnCard(
+                    deckId, deckCardNumber, BASIC, sbDeckDto.deckUUID, reviewAmount
+                )
+                insertBasicCard(
+                    BasicCard(
+                        cardId = cardId.toInt(),
+                        question = ct.basicCard.question,
+                        answer = ct.basicCard.answer
+                    )
+                )
+            }
+
+            is SealedCTToImport.Three -> {
+                val cardId = returnCard(
+                    deckId, deckCardNumber, THREE, sbDeckDto.deckUUID, reviewAmount
+                )
+                insertThreeCard(
+                    ThreeFieldCard(
+                        cardId = cardId.toInt(),
+                        question = ct.threeCard.question,
+                        middle = ct.threeCard.middle,
+                        answer = ct.threeCard.answer
+                    )
+                )
+            }
+
+            is SealedCTToImport.Hint -> {
+                val cardId = returnCard(
+                    deckId, deckCardNumber, HINT, sbDeckDto.deckUUID, reviewAmount
+                )
+                insertHintCard(
+                    HintCard(
+                        cardId = cardId.toInt(),
+                        question = ct.hintCard.question,
+                        hint = ct.hintCard.hint,
+                        answer = ct.hintCard.answer
+                    )
+                )
+            }
+
+            is SealedCTToImport.Multi -> {
+                val cardId = returnCard(
+                    deckId, deckCardNumber, MULTI, sbDeckDto.deckUUID, reviewAmount
+                )
+                insertMultiChoiceCard(
+                    MultiChoiceCard(
+                        cardId = cardId.toInt(),
+                        question = ct.multiCard.question,
+                        choiceA = ct.multiCard.choiceA,
+                        choiceB = ct.multiCard.choiceB,
+                        choiceC = ct.multiCard.choiceC,
+                        choiceD = ct.multiCard.choiceD,
+                        correct = ct.multiCard.correct
+                    )
+                )
+            }
+
+            is SealedCTToImport.Notation -> {
+                val cardId = returnCard(
+                    deckId, deckCardNumber, NOTATION, sbDeckDto.deckUUID, reviewAmount
+                )
+                insertNotationCard(
+                    NotationCard(
+                        cardId = cardId.toInt(),
+                        question = ct.notationCard.question,
+                        steps = ct.notationCard.steps,
+                        answer = ct.notationCard.answer
+                    )
+                )
+            }
+        }
+    }
+    private suspend fun returnCard(
+        deckId: Int, newDeckCardNumber: Int, type: String, uuid: String, reviewAmount: Int
+    ): Long {
+        return insertCard(
+            Card(
+                deckId = deckId,
+                nextReview = Date(),
+                passes = 0,
+                prevSuccess = false,
+                totalPasses = 0,
+                type = type,
+                deckUUID = uuid,
+                deckCardNumber = newDeckCardNumber,
+                cardIdentifier = "${uuid}-$newDeckCardNumber",
+                reviewsLeft = reviewAmount,
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/model/application/AppContainer.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/model/application/AppContainer.kt
@@ -23,6 +23,8 @@ import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.SupabaseToRoomRepository
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.DeepLinkerRepository
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.DeepLinkerRepositoryImpl
+import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.ForgotPasswordRepoImpl
+import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.ForgotPasswordRepository
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.IsOwnerOrCoOwnerRepo
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.IsOwnerOrCoOwnerRepoImpl
 import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.ownerRepos.MergeDecksRepository
@@ -55,6 +57,7 @@ interface AppContainer {
     val mergeDecksRepository: MergeDecksRepository
     val isOwnerOrCoOwnerRepo : IsOwnerOrCoOwnerRepo
     val deepLinkerRepo : DeepLinkerRepository
+    val fpRepository : ForgotPasswordRepository
 }
 
 class AppDataContainer(
@@ -133,5 +136,9 @@ class AppDataContainer(
     }
     override val deepLinkerRepo: DeepLinkerRepository by lazy {
         DeepLinkerRepositoryImpl(sharedSupabase)
+    }
+
+    override val fpRepository: ForgotPasswordRepository by lazy {
+        ForgotPasswordRepoImpl(sharedSupabase)
     }
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/model/application/AppViewModelProvider.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/model/application/AppViewModelProvider.kt
@@ -19,6 +19,7 @@ import com.belmontCrest.cardCrafter.controller.viewModels.deckViewsModels.DeckVi
 import com.belmontCrest.cardCrafter.controller.viewModels.deckViewsModels.EditDeckViewModel
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.CoOwnerViewModel
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.DeepLinksViewModel
+import com.belmontCrest.cardCrafter.supabase.controller.viewModels.ForgotPasswordViewModel
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.ImportDeckViewModel
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.PersonalDeckSyncViewModel
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.UserExportedDecksViewModel
@@ -128,6 +129,11 @@ object AppViewModelProvider {
         initializer {
             DeepLinksViewModel(
                 flashCardApplication().container.deepLinkerRepo
+            )
+        }
+        initializer {
+            ForgotPasswordViewModel(
+                flashCardApplication().container.fpRepository
             )
         }
     }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/destinations/SBDestinations.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/destinations/SBDestinations.kt
@@ -43,3 +43,8 @@ object SBCardListDestination : NavigationDestination {
 object CoOwnerRequestsDestination : NavigationDestination {
     override val route = "CoOwnerRequests"
 }
+
+@Serializable
+object ForgotPasswordDestination : NavigationDestination {
+    override val route = "ForgotPassword"
+}

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/SBNavHost.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/SBNavHost.kt
@@ -31,6 +31,7 @@ import com.belmontCrest.cardCrafter.controller.viewModels.deckViewsModels.update
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.model.uiModels.PreferencesManager
 import com.belmontCrest.cardCrafter.navigation.destinations.CoOwnerRequestsDestination
+import com.belmontCrest.cardCrafter.navigation.destinations.ForgotPasswordDestination
 import com.belmontCrest.cardCrafter.navigation.destinations.SBCardListDestination
 import com.belmontCrest.cardCrafter.navigation.destinations.UseEmailDestination
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.CoOwnerViewModel
@@ -43,6 +44,7 @@ import com.belmontCrest.cardCrafter.supabase.view.importDeck.ImportDeck
 import com.belmontCrest.cardCrafter.supabase.view.OnlineDatabase
 import com.belmontCrest.cardCrafter.supabase.view.uploadDeck.UploadThisDeck
 import com.belmontCrest.cardCrafter.supabase.view.authViews.email.EmailView
+import com.belmontCrest.cardCrafter.supabase.view.authViews.email.ForgotPassword
 import com.belmontCrest.cardCrafter.supabase.view.profile.CardListView
 import com.belmontCrest.cardCrafter.supabase.view.profile.RequestsView
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
@@ -78,7 +80,7 @@ fun SupabaseNav(
         UserEDDestination.route
     }
     val uEDVM: UserExportedDecksViewModel = viewModel(factory = AppViewModelProvider.Factory)
-    val clv = CardListView(uEDVM, getUIStyle)
+    val clv = CardListView(uEDVM, getUIStyle, preferences)
     NavHost(
         navController = sbNavController,
         startDestination = startDestination,
@@ -138,8 +140,22 @@ fun SupabaseNav(
                             SupabaseDestination.route, inclusive = false
                         )
                     }
+                },
+                onForgotPassword = {
+                    navViewModel.updateRoute(ForgotPasswordDestination.route)
+                    sbNavController.navigate(ForgotPasswordDestination.route)
                 }
             )
+        }
+
+        composable(ForgotPasswordDestination.route) {
+            BackHandler {
+                navViewModel.updateRoute(UseEmailDestination.route)
+                sbNavController.popBackStack(
+                    UseEmailDestination.route, inclusive = false
+                )
+            }
+            ForgotPassword(getUIStyle)
         }
         composable(
             ImportSBDestination.route,

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/controller/viewModels/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/controller/viewModels/ForgotPasswordViewModel.kt
@@ -1,0 +1,14 @@
+package com.belmontCrest.cardCrafter.supabase.controller.viewModels
+
+import androidx.lifecycle.ViewModel
+import com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo.ForgotPasswordRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ForgotPasswordViewModel(
+    private val fpRepository: ForgotPasswordRepository
+) : ViewModel() {
+    suspend fun forgotPassword(email: String): Boolean {
+        return withContext(Dispatchers.IO) { fpRepository.forgotPassword(email) }
+    }
+}

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/createSupabase/CreateSupabase.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/createSupabase/CreateSupabase.kt
@@ -13,7 +13,7 @@ import io.ktor.client.plugins.websocket.WebSockets
 
 private object AuthConfig {
     val FLOW_TYPE = FlowType.PKCE
-    const val SCHEME = "app"
+    const val APP_SCHEME = "app"
     const val HOST = "supabase.com"
 }
 /** Creating our supabase client for the user to use if they sign in/up. */
@@ -30,7 +30,7 @@ fun createSharedSupabase(
         install(Postgrest)
         install(Auth) {
             flowType = AuthConfig.FLOW_TYPE
-            scheme = AuthConfig.SCHEME
+            scheme = AuthConfig.APP_SCHEME
             host = AuthConfig.HOST
         }
         httpConfig {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/daos/MergeDecksDao.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/daos/MergeDecksDao.kt
@@ -10,32 +10,28 @@ import com.belmontCrest.cardCrafter.controller.cardHandlers.mapAllCardTypesToCTs
 import com.belmontCrest.cardCrafter.controller.cardHandlers.toCard
 import com.belmontCrest.cardCrafter.controller.cardHandlers.toCardList
 import com.belmontCrest.cardCrafter.localDatabase.tables.AllCardTypes
-import com.belmontCrest.cardCrafter.localDatabase.tables.BasicCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.localDatabase.tables.Card
 import com.belmontCrest.cardCrafter.localDatabase.tables.CardInfo
 import com.belmontCrest.cardCrafter.localDatabase.tables.Deck
-import com.belmontCrest.cardCrafter.localDatabase.tables.HintCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.ImportedDeckInfo
-import com.belmontCrest.cardCrafter.localDatabase.tables.MultiChoiceCard
-import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
-import com.belmontCrest.cardCrafter.localDatabase.tables.ThreeFieldCard
-import com.belmontCrest.cardCrafter.model.InsertAndReplaceDao
-import com.belmontCrest.cardCrafter.model.Type.BASIC
-import com.belmontCrest.cardCrafter.model.Type.HINT
-import com.belmontCrest.cardCrafter.model.Type.MULTI
-import com.belmontCrest.cardCrafter.model.Type.NOTATION
-import com.belmontCrest.cardCrafter.model.Type.THREE
+import com.belmontCrest.cardCrafter.model.TransactionCT
 import com.belmontCrest.cardCrafter.supabase.model.tables.SBDeckDto
 import com.belmontCrest.cardCrafter.supabase.model.tables.SealedCTToImport
 import com.belmontCrest.cardCrafter.supabase.model.tables.toCard
 import java.util.Date
 
 @Dao
-interface MergeDecksDao : InsertAndReplaceDao {
+interface MergeDecksDao : TransactionCT {
 
     @Query("SELECT * from decks where uuid = :uuid")
     suspend fun getDeck(uuid: String): Deck
+
+    @Query("SELECT * from decks where uuid = :uuid")
+    suspend fun doesDeckExist(uuid: String) : Deck?
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    fun insertDeck(deck: Deck): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertImportedDeckInfo(importedDeckInfo: ImportedDeckInfo)
@@ -86,6 +82,43 @@ interface MergeDecksDao : InsertAndReplaceDao {
     """
     )
     suspend fun dropCardsNotIn(deckId: Int, keepIds: List<String>)
+
+    @Transaction
+    suspend fun insertDeckList(
+        sbDeckDto: SBDeckDto, cardList: List<SealedCTToImport>,
+        reviewAmount: Int, cardAmount: Int,
+        onProgress: (Float) -> Unit
+    ) {
+        var current = 0
+        var total = cardList.size + 2
+        val deckId = insertDeck(
+            Deck(
+                name = sbDeckDto.name,
+                uuid = sbDeckDto.deckUUID,
+                nextReview = Date(),
+                lastUpdated = Date(),
+                reviewAmount = reviewAmount,
+                cardAmount = cardAmount
+            )
+        )
+        current += 1
+        onProgress((current).toFloat() / total)
+        insertImportedDeckInfo(
+            ImportedDeckInfo(
+                uuid = sbDeckDto.deckUUID,
+                lastUpdatedOn = sbDeckDto.updatedOn
+            )
+        )
+        current += 1
+        onProgress((current).toFloat() / total)
+        cardList.forEachIndexed { index, ct ->
+            insertTransactionCT(
+                ct, deckId.toInt(), sbDeckDto, reviewAmount
+            )
+            current += 1
+            onProgress((current).toFloat() / total)
+        }
+    }
 
     @Transaction
     suspend fun mergeDeck(
@@ -209,86 +242,6 @@ interface MergeDecksDao : InsertAndReplaceDao {
                     ct.card.type, sbDeckDto.deckUUID, reviewAmount
                 )
                 insertNotationCard(ct.notationCard.copy(cardId = cardId.toInt()))
-            }
-        }
-    }
-
-    private suspend fun insertTransactionCT(
-        ct: SealedCTToImport, deckId: Int, sbDeckDto: SBDeckDto, reviewAmount: Int
-    ) {
-        val cardIdentifier = ct.toCard().cardIdentifier
-        val deckCardNumber = cardIdentifier.substringAfterLast("-").toInt()
-        when (ct) {
-            is SealedCTToImport.Basic -> {
-                val cardId = returnCard(
-                    deckId.toInt(), deckCardNumber, BASIC, sbDeckDto.deckUUID, reviewAmount
-                )
-                insertBasicCard(
-                    BasicCard(
-                        cardId = cardId.toInt(),
-                        question = ct.basicCard.question,
-                        answer = ct.basicCard.answer
-                    )
-                )
-            }
-
-            is SealedCTToImport.Three -> {
-                val cardId = returnCard(
-                    deckId.toInt(), deckCardNumber, THREE, sbDeckDto.deckUUID, reviewAmount
-                )
-                insertThreeCard(
-                    ThreeFieldCard(
-                        cardId = cardId.toInt(),
-                        question = ct.threeCard.question,
-                        middle = ct.threeCard.middle,
-                        answer = ct.threeCard.answer
-                    )
-                )
-            }
-
-            is SealedCTToImport.Hint -> {
-                val cardId = returnCard(
-                    deckId.toInt(), deckCardNumber, HINT, sbDeckDto.deckUUID, reviewAmount
-                )
-                insertHintCard(
-                    HintCard(
-                        cardId = cardId.toInt(),
-                        question = ct.hintCard.question,
-                        hint = ct.hintCard.hint,
-                        answer = ct.hintCard.answer
-                    )
-                )
-            }
-
-            is SealedCTToImport.Multi -> {
-                val cardId = returnCard(
-                    deckId.toInt(), deckCardNumber, MULTI, sbDeckDto.deckUUID, reviewAmount
-                )
-                insertMultiChoiceCard(
-                    MultiChoiceCard(
-                        cardId = cardId.toInt(),
-                        question = ct.multiCard.question,
-                        choiceA = ct.multiCard.choiceA,
-                        choiceB = ct.multiCard.choiceB,
-                        choiceC = ct.multiCard.choiceC,
-                        choiceD = ct.multiCard.choiceD,
-                        correct = ct.multiCard.correct
-                    )
-                )
-            }
-
-            is SealedCTToImport.Notation -> {
-                val cardId = returnCard(
-                    deckId.toInt(), deckCardNumber, NOTATION, sbDeckDto.deckUUID, reviewAmount
-                )
-                insertNotationCard(
-                    NotationCard(
-                        cardId = cardId.toInt(),
-                        question = ct.notationCard.question,
-                        steps = ct.notationCard.steps,
-                        answer = ct.notationCard.answer
-                    )
-                )
             }
         }
     }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/AuthRepository.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/AuthRepository.kt
@@ -32,6 +32,4 @@ interface AuthRepository {
     suspend fun signOut(): Boolean
 
     suspend fun signInSyncedDBUser(): String
-
-    suspend fun forgotPassword(inputEmail: String): Boolean
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/AuthRepositoryImpl.kt
@@ -23,7 +23,6 @@ import io.github.jan.supabase.gotrue.exception.AuthWeakPasswordException
 import io.github.jan.supabase.gotrue.providers.Google
 import io.github.jan.supabase.gotrue.providers.builtin.Email
 import io.github.jan.supabase.gotrue.providers.builtin.IDToken
-import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.query.Columns
 import io.ktor.client.call.body
@@ -158,7 +157,7 @@ class AuthRepositoryImpl(
             try {
                 sharedSupabase.auth.signUpWith(
                     provider = Email,
-                    redirectUrl = "app://supabase.com"
+                    redirectUrl = "app://supabase.com/auth-callback"
                 ) {
                     email = inputEmail
                     password = inputPassword
@@ -314,20 +313,6 @@ class AuthRepositoryImpl(
             } catch (e: Exception) {
                 Log.e(VS.AUTH_REPO, "$e")
                 return@withContext "Something went wrong"
-            }
-        }
-    }
-
-    override suspend fun forgotPassword(inputEmail: String): Boolean {
-        return withContext(Dispatchers.IO) {
-            try {
-                sharedSupabase.auth.resetPasswordForEmail(
-                    email = inputEmail, redirectUrl = "reset://supabase.com"
-                )
-                true
-            } catch (e: Exception) {
-                Log.e(VS.AUTH_REPO, "$e")
-                false
             }
         }
     }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/ForgotPasswordRepository.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/authRepo/ForgotPasswordRepository.kt
@@ -1,0 +1,34 @@
+package com.belmontCrest.cardCrafter.supabase.model.daoAndRepository.repositories.authRepo
+
+import android.util.Log
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.auth
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+interface ForgotPasswordRepository {
+    suspend fun forgotPassword(inputEmail: String): Boolean
+}
+
+class ForgotPasswordRepoImpl(
+    private val sharedSupabase: SupabaseClient
+) : ForgotPasswordRepository {
+
+    companion object {
+        private const val FPR = "ForgotPasswordRepository"
+    }
+
+    override suspend fun forgotPassword(inputEmail: String): Boolean {
+        return withContext(Dispatchers.IO) {
+            try {
+                sharedSupabase.auth.resetPasswordForEmail(
+                    email = inputEmail, redirectUrl = "app://supabase.com/reset-callback"
+                )
+                true
+            } catch (e: Exception) {
+                Log.e(FPR, "$e")
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/ownerRepos/MergeDecksRepository.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/model/daoAndRepository/repositories/ownerRepos/MergeDecksRepository.kt
@@ -8,6 +8,14 @@ interface MergeDecksRepository {
     suspend fun mergeDeck(
         sbDeckDto: SBDeckDto, remoteCL: List<SealedCTToImport>, onProgress: (Float) -> Unit
     )
+
+    suspend fun doesDeckExist(uuid: String): Boolean
+
+    suspend fun insertDeckList(
+        sbDeckDto: SBDeckDto, cardList: List<SealedCTToImport>,
+        reviewAmount: Int, cardAmount: Int,
+        onProgress: (Float) -> Unit
+    )
 }
 
 class OfflineMergeDecksRepository(
@@ -17,5 +25,15 @@ class OfflineMergeDecksRepository(
         sbDeckDto: SBDeckDto, remoteCL: List<SealedCTToImport>, onProgress: (Float) -> Unit
     ) = mergeDecksDao.mergeDeck(
         sbDeckDto, remoteCL
+    ) { onProgress(it) }
+
+    override suspend fun doesDeckExist(uuid: String): Boolean =
+        mergeDecksDao.doesDeckExist(uuid) != null
+
+    override suspend fun insertDeckList(
+        sbDeckDto: SBDeckDto, cardList: List<SealedCTToImport>,
+        reviewAmount: Int, cardAmount: Int, onProgress: (Float) -> Unit
+    ) = mergeDecksDao.insertDeckList(
+        sbDeckDto, cardList,reviewAmount, cardAmount
     ) { onProgress(it) }
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/authViews/email/EmailView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/authViews/email/EmailView.kt
@@ -42,7 +42,8 @@ import kotlinx.coroutines.launch
 @RequiresApi(Build.VERSION_CODES.Q)
 @Composable
 fun EmailView(
-    supabaseVM: SupabaseViewModel, getUIStyle: GetUIStyle, onNavigate: () -> Unit,
+    supabaseVM: SupabaseViewModel, getUIStyle: GetUIStyle,
+    onNavigate: () -> Unit, onForgotPassword: () -> Unit
 ) {
     val context = LocalContext.current
     var inputEmail = rememberSaveable { mutableStateOf("") }
@@ -75,7 +76,8 @@ fun EmailView(
                     inputEmail = inputEmail, inputPassword = inputPassword,
                     enabled = enabled, coroutineScope = coroutineScope,
                     supabaseVM = supabaseVM, context = context, signIn = signIn,
-                    getUIStyle = getUIStyle, onNavigate = onNavigate
+                    getUIStyle = getUIStyle, onNavigate = onNavigate,
+                    onForgotPassword = onForgotPassword
                 )
             }
         }
@@ -182,7 +184,7 @@ private fun SignInWithEmail(
     inputEmail: MutableState<String>, inputPassword: MutableState<String>,
     enabled: MutableState<Boolean>, coroutineScope: CoroutineScope, getUIStyle: GetUIStyle,
     supabaseVM: SupabaseViewModel, context: Context, signIn: MutableState<Boolean>,
-    onNavigate: () -> Unit
+    onNavigate: () -> Unit, onForgotPassword: () -> Unit
 ) {
     var errorMessage by rememberSaveable { mutableStateOf("") }
     val success = stringResource(R.string.signed_in)
@@ -194,15 +196,32 @@ private fun SignInWithEmail(
         labelStr = "Email",
         modifier = Modifier.fillMaxWidth(),
     )
-    PasswordTextField(
-        password = inputPassword.value,
-        onPasswordChange = {
-            inputPassword.value = it
-        },
-        label = "Password",
-        modifier = Modifier.fillMaxWidth(),
-        getUIStyle = getUIStyle
-    )
+    Column(
+        modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        PasswordTextField(
+            password = inputPassword.value,
+            onPasswordChange = {
+                inputPassword.value = it
+            },
+            label = "Password",
+            modifier = Modifier.fillMaxWidth(),
+            getUIStyle = getUIStyle
+        )
+        Text(
+            text = "Forgot password",
+            color = Color.Red,
+            modifier = Modifier
+                .padding(4.dp)
+                .clickable {
+                    if (enabled.value) {
+                        onForgotPassword()
+                    }
+                }
+                .align(Alignment.End),
+            fontSize = 13.sp
+        )
+    }
     Spacer(Modifier.padding(vertical = 20.dp))
     SubmitButton(
         onClick = {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/authViews/email/ForgotPassword.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/authViews/email/ForgotPassword.kt
@@ -1,0 +1,67 @@
+package com.belmontCrest.cardCrafter.supabase.view.authViews.email
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.belmontCrest.cardCrafter.model.application.AppViewModelProvider
+import com.belmontCrest.cardCrafter.supabase.controller.viewModels.ForgotPasswordViewModel
+import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
+import com.belmontCrest.cardCrafter.ui.theme.boxViewsModifier
+import com.belmontCrest.cardCrafter.uiFunctions.CustomText
+import com.belmontCrest.cardCrafter.uiFunctions.EditTextField
+import com.belmontCrest.cardCrafter.uiFunctions.SubmitButton
+import com.belmontCrest.cardCrafter.uiFunctions.showToastMessage
+import kotlinx.coroutines.launch
+
+@RequiresApi(Build.VERSION_CODES.Q)
+@Composable
+fun ForgotPassword(getUIStyle: GetUIStyle) {
+    var inputEmail by rememberSaveable { mutableStateOf("") }
+    var enabled by rememberSaveable { mutableStateOf(true) }
+    val coroutineScope = rememberCoroutineScope()
+    val fpVM: ForgotPasswordViewModel = viewModel(factory = AppViewModelProvider.Factory)
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.boxViewsModifier(getUIStyle.getColorScheme()),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CustomText(
+            "Please enter you email", getUIStyle, Modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+        )
+        EditTextField(
+            value = inputEmail, onValueChanged = { inputEmail = it },
+            labelStr = "Email", Modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+        )
+        SubmitButton(onClick = {
+            coroutineScope.launch {
+                enabled = false
+                val result = fpVM.forgotPassword(inputEmail)
+                if (!result) {
+                    showToastMessage(context, "Failed to send email.")
+                } else {
+                    showToastMessage(context, "Sent, please check your email.")
+                }
+                enabled = true
+            }
+        }, enabled, getUIStyle, "Send email")
+    }
+}

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/profile/CardListView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/profile/CardListView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -37,6 +36,7 @@ import com.belmontCrest.cardCrafter.model.TextProps
 import com.belmontCrest.cardCrafter.model.Type
 import com.belmontCrest.cardCrafter.model.cardListTextProp
 import com.belmontCrest.cardCrafter.model.toTextProp
+import com.belmontCrest.cardCrafter.model.uiModels.PreferencesManager
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.UserExportedDecksViewModel
 import com.belmontCrest.cardCrafter.supabase.model.ReturnValues.SUCCESS
 import com.belmontCrest.cardCrafter.supabase.model.tables.CoOwnerWithUsername
@@ -58,7 +58,8 @@ import kotlinx.coroutines.launch
 
 class CardListView(
     private val uEDVM: UserExportedDecksViewModel,
-    private val getUIStyle: GetUIStyle
+    private val getUIStyle: GetUIStyle,
+    private val preferences: PreferencesManager
 ) {
     @Composable
     fun AllCards() {
@@ -135,7 +136,9 @@ class CardListView(
             PullDeck(Modifier.align(Alignment.BottomEnd), getUIStyle) {
                 coroutineScope.launch {
                     enabled = false
-                    val result = uEDVM.mergeRemoteWithLocal { progress = it }
+                    val result = uEDVM.mergeRemoteWithLocal(
+                        preferences.reviewAmount.intValue, preferences.cardAmount.intValue
+                    ) { progress = it }
 
                     if (result != SUCCESS) {
                         showToastMessage(context, "No success.")


### PR DESCRIPTION
## Summary by Sourcery

Enable users to request a password reset email and complete resets through deep-linked ResetPasswordActivity while refactoring deck merge transactions, view model state handling, and UI layout consistency

New Features:
- Add forgot password request screen and repository to send reset email
- Extend sign-in UI with “Forgot password” link to navigate to the reset request
- Implement ResetPasswordActivity to handle password reset via deep link

Enhancements:
- Extract deck import logic into TransactionCT interface with insertDeckList and existence check
- Refactor CardDeckViewModel state keys and convert SavedCard mapping to extension method
- Replace Surface with Scaffold and adjust padding/alignment across activities
- Register ForgotPasswordRepository and ViewModel in application container and navigation