### PR TITLE
Fix DisplayCardDetails.kt web view, move KatexMapping.kt and for some reason now all the mapping works lol

### DIFF
--- a/app/src/main/assets/deck_content.html
+++ b/app/src/main/assets/deck_content.html
@@ -25,9 +25,16 @@
        }
 
        .card-render {
+           box-sizing: border-box;
            margin: auto;
            font-size: 22px;
            text-align: start;
+           width: 100%;
+           border-style: outset;
+           border-width: 2px;
+           padding: 0px 2px 0px 2px;
+           margin-top: 4px;
+           margin-bottom: 2px;
         }
     </style>
 </head>
@@ -55,26 +62,15 @@
       });
     }
 
-    function setDeckTitle(text) {
-      document.getElementById('deckTitle').innerHTML = text;
-    }
-
-    function setDescription(text) {
-        const slot = document.getElementById('description');
-        slot.innerHTML = text;
-        renderNotation(slot)
-
-    }
-
-    function setCard(index, text) {
-      const slot = document.getElementById(`card${index}`);
-      slot.innerHTML = text;
-      renderNotation(slot);
-    }
-
     function setTheme(bg, fg) {
       document.body.style.backgroundColor = bg;
       document.body.style.color = fg;
+    }
+    function setBorderColor(bc) {
+      // grab every element with class="card-render"
+      document.querySelectorAll('.card-render').forEach(el => {
+            el.style.borderColor = bc;
+      });
     }
 </script>
 </body>

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/Buttons.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/Buttons.kt
@@ -179,7 +179,6 @@ fun SettingsButton(
     fields: Fields
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val coroutineScope = rememberCoroutineScope()
     IconButton(
         onClick = {
             if (!fields.inDeckClicked.value) {
@@ -204,11 +203,8 @@ fun SettingsButton(
             DropdownMenuItem(
                 onClick = {
                     expanded = false
-                    coroutineScope.launch {
-                        fields.mainClicked.value = true
-                        delayNavigate()
-                        onNavigateToEditDeck()
-                    }
+                    fields.mainClicked.value = true
+                    onNavigateToEditDeck()
                 },
                 text = { Text(stringResource(R.string.edit_deck)) })
             DropdownMenuItem(

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/KeyboardInputs.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/KeyboardInputs.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.sp
 import com.belmontCrest.cardCrafter.R
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.textColor
-import com.belmontCrest.cardCrafter.views.miscFunctions.symbols.katexMapper
+import com.belmontCrest.cardCrafter.uiFunctions.symbols.katexMapper
 
 /** This more for the MultiChoiceCard Choice inputs */
 @Composable

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/KatexMapping.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/KatexMapping.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.views.miscFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.symbols
 
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/KatexView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/KatexView.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.views.miscFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.symbols
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
@@ -32,7 +32,7 @@ fun KaTeXWebView(latexExpression: String, getUIStyle: GetUIStyle) {
             }
         }, modifier = Modifier
             .fillMaxWidth()
-            .zIndex(-1f)
+            .zIndex(-1f),
     ) { view ->
         view.loadUrl("file:///android_asset/katex.html")
         view.webViewClient = object : WebViewClient() {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/SymbolDocumentation.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/symbols/SymbolDocumentation.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.views.miscFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.symbols
 
 
 import androidx.compose.foundation.clickable
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,14 +24,15 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.sp
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
+import com.belmontCrest.cardCrafter.uiFunctions.SubmitButton
 
 @Composable
 fun SymbolDocumentation(
     pressed: MutableState<Boolean>,
     getUIStyle: GetUIStyle
 ) {
-    val introduction = """
-        Mapping text to an equation/notation correctly is important.
+    val introduction =
+        """Mapping text to an equation/notation correctly is important.
         |To see examples on how to map more complex symbols:
     """.trimMargin()
     val clickHere = "Click here"
@@ -56,6 +55,8 @@ fun SymbolDocumentation(
             |$$\\frac{4\\pi}{3} r^{3}$$
             |This should give you the following:
         """.trimMargin()
+
+    val result = "$$\\\\frac{4\\\\pi}{3}r^{3}$$"
 
     val returnToTop = "\nReturn to top"
 
@@ -111,6 +112,7 @@ fun SymbolDocumentation(
                         fontSize = 20.sp,
                         lineHeight = 30.sp
                     )
+                    KaTeXWebView(result, getUIStyle)
                     Text(
                         text = returnToTop,
                         color = Color.Blue,
@@ -125,15 +127,7 @@ fun SymbolDocumentation(
             },
             confirmButton = { },
             dismissButton = {
-                Button(
-                    onClick = { pressed.value = false },
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = getUIStyle.secondaryButtonColor(),
-                        contentColor = getUIStyle.buttonTextColor()
-                    )
-                ) {
-                    Text("OK")
-                }
+                SubmitButton(onClick = { pressed.value = false }, true, getUIStyle, "OK")
             },
             modifier = Modifier
                 .fillMaxWidth(.975f)

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
@@ -33,7 +33,7 @@ import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.boxViewsModifier
 import com.belmontCrest.cardCrafter.views.miscFunctions.getSavableFields
-import com.belmontCrest.cardCrafter.views.miscFunctions.symbols.SymbolDocumentation
+import com.belmontCrest.cardCrafter.uiFunctions.symbols.SymbolDocumentation
 
 
 class AddCardView(

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/BackCards.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/BackCards.kt
@@ -25,7 +25,7 @@ import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.MultiChoiceCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.ThreeFieldCard
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
-import com.belmontCrest.cardCrafter.views.miscFunctions.symbols.KaTeXWebView
+import com.belmontCrest.cardCrafter.uiFunctions.symbols.KaTeXWebView
 
 private const val line = "$$\\\\text{---}\\\\text{---}\\\\text{---}\\\\text{---}\\\\text{---}" +
         "\\\\text{---}\\\\text{---}\\\\text{---}$$"

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/FrontCards.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/FrontCards.kt
@@ -32,7 +32,7 @@ import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.R
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
-import com.belmontCrest.cardCrafter.views.miscFunctions.symbols.KaTeXWebView
+import com.belmontCrest.cardCrafter.uiFunctions.symbols.KaTeXWebView
 
 @Composable
 fun FrontCard(


### PR DESCRIPTION
## Summary by Sourcery

Refactor card detail rendering web view to use direct DOM manipulation for theming, deck metadata, and individual card content with border styling; enhance card-content.html styling; migrate all KaTeX and symbol mapping utilities into a unified uiFunctions.symbols package; simplify UI components by replacing raw Button with SubmitButton and removing unnecessary coroutine logic in SettingsButton.

Enhancements:
- Inject theme colors, deck title, description, and each card HTML via separate evaluateJavascript calls in DisplayCardDetails
- Add border color support and update .card-render CSS in deck_content.html for consistent layout and styling
- Replace manual Button in SymbolDocumentation with shared SubmitButton component
- Simplify SettingsButton by removing coroutine delay and invoking navigation directly

Chores:
- Move KatexMapping.kt, SymbolDocumentation.kt, KaTeXWebView, and related symbol utilities from views.miscFunctions.symbols to uiFunctions.symbols package
- Update import paths across various components to reflect relocated symbol utility packages