### PR TITLE
katex-menu

### DIFF
--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardTypeHandler.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardTypeHandler.kt
@@ -5,14 +5,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Modifier
-import com.belmontCrest.cardCrafter.controller.viewModels.cardViewsModels.EditCardViewModel
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
+import com.belmontCrest.cardCrafter.navigation.NavViewModel
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditBasicCard
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditHintCard
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditThreeCard
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
+import com.belmontCrest.cardCrafter.uiFunctions.katex.KaTeXMenu
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditChoiceCard
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditNotationCard
 import com.belmontCrest.cardCrafter.views.miscFunctions.details.createBasicCardDetails
@@ -23,16 +23,16 @@ import com.belmontCrest.cardCrafter.views.miscFunctions.details.createThreeOrHin
 interface CardTypeHandler {
     @Composable
     fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     )
 }
 
 class BasicCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     ) {
 
         if (ct is CT.Basic) {
@@ -63,8 +63,8 @@ class BasicCardTypeHandler : CardTypeHandler {
 class ThreeCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     ) {
         if (ct is CT.ThreeField) {
             if (!changed) {
@@ -105,8 +105,8 @@ class ThreeCardTypeHandler : CardTypeHandler {
 class HintCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     ) {
         if (ct is CT.Hint) {
             if (!changed) {
@@ -145,8 +145,8 @@ class HintCardTypeHandler : CardTypeHandler {
 class ChoiceCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     ) {
         if (ct is CT.MultiChoice) {
             if (!changed) {
@@ -188,8 +188,8 @@ class ChoiceCardTypeHandler : CardTypeHandler {
 class NotationCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields, ct: CT, vm: EditCardViewModel,
-        changed: Boolean, getUIStyle: GetUIStyle, modifier : Modifier
+        fields: Fields, ct: CT, vm: NavViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
     ) {
         if (ct is CT.Notation) {
             if (!changed) {
@@ -206,16 +206,16 @@ class NotationCardTypeHandler : CardTypeHandler {
                 fields.stringList = rememberSaveable { cardDetails.stringList }
                 fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
             }
-            EditNotationCard(fields, vm, getUIStyle, modifier)
+            EditNotationCard(fields, vm, getUIStyle, onUpdate)
         } else {
             if (ct is CT.Basic) {
-                EditNotationCard(fields, vm, getUIStyle, modifier)
+                EditNotationCard(fields, vm, getUIStyle, onUpdate)
             } else if (ct is CT.ThreeField) {
-                EditNotationCard(fields, vm, getUIStyle, modifier)
+                EditNotationCard(fields, vm, getUIStyle, onUpdate)
             } else if (ct is CT.Hint) {
-                EditNotationCard(fields, vm, getUIStyle, modifier)
+                EditNotationCard(fields, vm, getUIStyle, onUpdate)
             } else if (ct is CT.MultiChoice) {
-                EditNotationCard(fields, vm, getUIStyle, modifier)
+                EditNotationCard(fields, vm, getUIStyle, onUpdate)
             }
         }
     }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/AddCardViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/AddCardViewModel.kt
@@ -25,12 +25,6 @@ class AddCardViewModel(
     private val _errorMessage: MutableStateFlow<String> = MutableStateFlow("")
     val errorMessage = _errorMessage.asStateFlow()
     private val isOwner = MutableStateFlow(false)
-    private val _showKatexKeyboard = MutableStateFlow(false)
-    val showKatexKeyboard = _showKatexKeyboard.asStateFlow()
-    private val _selectedKB : MutableStateFlow<SelectedKeyboard?> = MutableStateFlow(null)
-    val selectedKB = _selectedKB.asStateFlow()
-    private val _resetOffset = MutableStateFlow(false)
-    val resetOffset = _resetOffset.asStateFlow()
 
     companion object {
         private const val TIMEOUT_MILLIS = 4_000L
@@ -163,26 +157,6 @@ class AddCardViewModel(
                 }
             }
         }
-    }
-
-    fun updateSelectedKB(selectedKeyboard: SelectedKeyboard) {
-            _selectedKB.update { selectedKeyboard }
-    }
-
-    fun resetSelectedKB() {
-        _selectedKB.update { null }
-    }
-
-    fun toggleKeyboard() {
-        _showKatexKeyboard.update { !it }
-    }
-
-    fun resetOffset() {
-        _resetOffset.update { true }
-    }
-
-    fun resetDone() {
-        _resetOffset.update { false }
     }
 
     fun setErrorMessage(message: String) {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/EditCardViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/EditCardViewModel.kt
@@ -7,7 +7,6 @@ import com.belmontCrest.cardCrafter.localDatabase.dbInterface.repositories.Scien
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.localDatabase.tables.ListStringConverter
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
-import com.belmontCrest.cardCrafter.model.uiModels.SelectedKeyboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,12 +21,6 @@ class EditCardViewModel(
     private val listStringConverter = ListStringConverter()
     private val privateErrMessage = MutableStateFlow("")
     val errorMessage = privateErrMessage.asStateFlow()
-    private val _showKatexKeyboard = MutableStateFlow(false)
-    val showKatexKeyboard = _showKatexKeyboard.asStateFlow()
-    private val _selectedKB : MutableStateFlow<SelectedKeyboard?> = MutableStateFlow(null)
-    val selectedKB = _selectedKB.asStateFlow()
-    private val _resetOffset = MutableStateFlow(false)
-    val resetOffset = _resetOffset.asStateFlow()
 
     fun updateBasicCard(cardId: Int, question: String, answer: String) {
         viewModelScope.launch {
@@ -85,26 +78,6 @@ class EditCardViewModel(
         viewModelScope.launch {
             cardTypeRepository.updateCT(cardId, type, fields, deleteCT)
         }.join()
-    }
-
-    fun updateSelectedKB(selectedKeyboard: SelectedKeyboard) {
-        _selectedKB.update { selectedKeyboard }
-    }
-
-    fun resetSelectedKB() {
-        _selectedKB.update { null }
-    }
-
-    fun toggleKeyboard() {
-        _showKatexKeyboard.update { !it }
-    }
-
-    fun resetOffset() {
-        _resetOffset.update { true }
-    }
-
-    fun resetDone() {
-        _resetOffset.update { false }
     }
 
     fun setErrorMessage(message: String) {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/NavViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/NavViewModel.kt
@@ -13,6 +13,7 @@ import com.belmontCrest.cardCrafter.localDatabase.dbInterface.repositories.Flash
 import com.belmontCrest.cardCrafter.localDatabase.tables.Card
 import com.belmontCrest.cardCrafter.model.uiModels.StringVar
 import com.belmontCrest.cardCrafter.model.uiModels.SelectedCard
+import com.belmontCrest.cardCrafter.model.uiModels.SelectedKeyboard
 import com.belmontCrest.cardCrafter.model.uiModels.WhichDeck
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -77,21 +78,17 @@ class NavViewModel(
 
     fun updateRoute(newRoute: String) {
         savedStateHandle["route"] = newRoute
-        _route.update {
-            StringVar(newRoute)
-        }
+        _route.update { StringVar(newRoute) }
     }
 
     private val _startingDeckRoute = MutableStateFlow(
         StringVar(savedStateHandle["startDeckRoute"] ?: DeckViewDestination.route)
     )
-
     val startingDeckRoute = _startingDeckRoute.asStateFlow()
+
     fun updateStartingDeckRoute(newRoute: String) {
         savedStateHandle["startDeckRoute"] = newRoute
-        _startingDeckRoute.update {
-            StringVar(newRoute)
-        }
+        _startingDeckRoute.update { StringVar(newRoute) }
     }
 
     private val _startingSBRoute = MutableStateFlow(
@@ -106,32 +103,28 @@ class NavViewModel(
         }
     }
 
-    private val _wd: StateFlow<WhichDeck> = deckId
-        .flatMapLatest { id ->
-            if (id == 0) {
-                flowOf(WhichDeck())
-            } else {
-                flashCardRepository.getDeckStream(id).map {
-                    WhichDeck(it)
-                }
+    val wd: StateFlow<WhichDeck> = deckId.flatMapLatest { id ->
+        if (id == 0) {
+            flowOf(WhichDeck())
+        } else {
+            flashCardRepository.getDeckStream(id).map {
+                WhichDeck(it)
             }
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
-            initialValue = WhichDeck()
-        )
-    val wd = _wd
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+        initialValue = WhichDeck()
+    )
 
-    private val thisType = MutableStateFlow(savedStateHandle["type"] ?: "basic")
-    val type = thisType.asStateFlow()
+    private val _type = MutableStateFlow(savedStateHandle["type"] ?: "basic")
+    val type = _type.asStateFlow()
     fun updateType(newType: String) {
         savedStateHandle["type"] = newType
-        thisType.update {
-            newType
-        }
+        _type.update { newType }
     }
 
-    private val thisCard = cardId.flatMapLatest { id ->
+    val card = cardId.flatMapLatest { id ->
         if (id == 0) {
             flowOf(SelectedCard(null))
         } else {
@@ -150,13 +143,16 @@ class NavViewModel(
                 SelectedCard(cardTypeRepository.getACardType(cardId.value))
             }
     )
+    private val _showKatexKeyboard = MutableStateFlow(false)
+    val showKatexKeyboard = _showKatexKeyboard.asStateFlow()
+    private val _selectedKB: MutableStateFlow<SelectedKeyboard?> = MutableStateFlow(null)
+    val selectedKB = _selectedKB.asStateFlow()
+    private val _resetOffset = MutableStateFlow(false)
+    val resetOffset = _resetOffset.asStateFlow()
 
-    val card = thisCard
     fun getDeckById(id: Int) {
         savedStateHandle["id"] = id
-        deckId.update {
-            id
-        }
+        deckId.update { id }
 
     }
 
@@ -167,10 +163,8 @@ class NavViewModel(
     }
 
     fun getCardById(id: Int) {
-        savedStateHandle["cardId"] = 0
-        cardId.update {
-            id
-        }
+        savedStateHandle["cardId"] = id
+        cardId.update { id }
     }
 
     fun resetCard() {
@@ -182,14 +176,35 @@ class NavViewModel(
     private val _isBlocking = MutableStateFlow(false)
     val isBlocking = _isBlocking.asStateFlow()
     fun updateIsBlocking() {
-        _isBlocking.update {
-            true
-        }
+        _isBlocking.update { true }
     }
 
     fun resetIsBlocking() {
-        _isBlocking.update {
-            false
-        }
+        _isBlocking.update { false }
+    }
+
+    fun updateSelectedKB(selectedKeyboard: SelectedKeyboard) {
+        _selectedKB.update { selectedKeyboard }
+    }
+
+    fun resetSelectedKB() {
+        _selectedKB.update { null }
+    }
+
+    fun toggleKeyboard() {
+        _showKatexKeyboard.update { !it }
+    }
+
+    fun resetOffset() {
+        _resetOffset.update { true }
+    }
+
+    fun resetDone() {
+        _resetOffset.update { false }
+    }
+
+    fun resetKeyboardStuff() {
+        resetSelectedKB()
+        _showKatexKeyboard.update { false }
     }
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/drawer/ModalContent.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/drawer/ModalContent.kt
@@ -37,6 +37,8 @@ import com.belmontCrest.cardCrafter.model.toTextProp
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.model.uiModels.StringVar
 import com.belmontCrest.cardCrafter.model.uiModels.WhichDeck
+import com.belmontCrest.cardCrafter.navigation.destinations.AddCardDestination
+import com.belmontCrest.cardCrafter.navigation.destinations.EditingCardDestination
 import com.belmontCrest.cardCrafter.navigation.destinations.UserEDDestination
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.SupabaseViewModel
 import com.belmontCrest.cardCrafter.uiFunctions.showToastMessage
@@ -67,6 +69,7 @@ class ModalContent(
         )
         .zIndex(2f)
     private val ci = ContentIcons(getUIStyle)
+
     @Composable
     fun Home(coroutineScope: CoroutineScope) {
         val fontSize = returnFontSizeBasedOnDp()
@@ -74,9 +77,8 @@ class ModalContent(
             onClick = {
                 updateCards(coroutineScope)
                 fields.mainClicked.value = false
-                launchHome(
-                    coroutineScope, navViewModel, cardDeckVM, fields
-                )
+                resetKeyboardStuff()
+                launchHome(coroutineScope, navViewModel, cardDeckVM, fields)
                 navViewModel.updateRoute(DeckListDestination.route)
                 navController.navigate(DeckListDestination.route)
             })
@@ -90,6 +92,7 @@ class ModalContent(
     fun ExportDecks() {
         val fontSize = returnFontSizeBasedOnDp()
         CustomRow(onClick = {
+            resetKeyboardStuff()
             navViewModel.updateRoute(UserEDDestination.route)
             navViewModel.updateStartingSBRoute(UserEDDestination.route)
             navController.navigate(SBNavDestination.route)
@@ -107,11 +110,13 @@ class ModalContent(
         val fontSize = returnFontSizeBasedOnDp()
         CustomRow(
             onClick = {
+                resetKeyboardStuff()
                 updateCards(coroutineScope)
                 cardDeckVM.updateIndex(0)
                 navViewModel.updateRoute(SettingsDestination.route)
                 navController.navigate(SettingsDestination.route)
-            })
+            }
+        )
         {
             CustomText("Settings", getUIStyle, props = FSProp.Default.toTextProp(fontSize))
             ci.ContentIcon("Main Settings", Icons.Default.Settings, mdModifier)
@@ -125,6 +130,7 @@ class ModalContent(
         val context = LocalContext.current
         CustomRow(
             onClick = {
+                resetKeyboardStuff()
                 if (cr.name != UserProfileDestination.route) {
                     updateCards(coroutineScope)
                     navViewModel.updateStartingSBRoute(UserProfileDestination.route)
@@ -156,6 +162,13 @@ class ModalContent(
                     updateDecksCardList(it, cardDeckVM)
                 }
             }
+        }
+    }
+
+    /** Reset the offset, which keyboard is selected and if it should show. */
+    private fun resetKeyboardStuff() {
+        if (cr.name == AddCardDestination.route || cr.name == EditingCardDestination.route) {
+            navViewModel.resetKeyboardStuff()
         }
     }
 

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/DeckNavHost.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/DeckNavHost.kt
@@ -58,7 +58,7 @@ fun DeckNavHost(
         cardDeckVM, getUIStyle, fields
     )
     val editDeckView = EditDeckView(fields, getUIStyle)
-    val editingCardView = EditingCardView(getUIStyle)
+    val editingCardView = EditingCardView(getUIStyle, navViewModel)
     val editCardsList =
         EditCardsList(
             editingCardListVM,
@@ -141,6 +141,7 @@ fun DeckNavHost(
             BackHandler {
                 fields.inDeckClicked.value = false
                 fields.resetFields()
+                navViewModel.resetKeyboardStuff()
                 navViewModel.updateRoute(DeckViewDestination.route)
                 deckNavController.popBackStack(
                     DeckViewDestination.route,
@@ -256,6 +257,7 @@ fun DeckNavHost(
             BackHandler {
                 fields.navigateToCardList()
                 navViewModel.resetCard()
+                navViewModel.resetKeyboardStuff()
                 navViewModel.updateRoute(ViewAllCardsDestination.route)
                 deckNavController.popBackStack(
                     ViewAllCardsDestination.route,
@@ -267,6 +269,7 @@ fun DeckNavHost(
                     ct = it,
                     fields = fields,
                     onNavigateBack = {
+                        navViewModel.resetKeyboardStuff()
                         fields.navigateToCardList()
                         navViewModel.resetCard()
                         navViewModel.updateRoute(ViewAllCardsDestination.route)

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexSA.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexSA.kt
@@ -1,0 +1,32 @@
+package com.belmontCrest.cardCrafter.uiFunctions.katex
+
+import android.util.Log
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/**
+ * Add the notation to the given text field and update the textFieldValue
+ * @param textFieldValue The current textFieldValue
+ * @param text The current text in the textFieldValue
+ * @param kk Just the `const val` of the KatexKeyboard for debugging
+ * @param notation The notation to add
+ * @param offset How far back to move the cursor
+ * @param onValueChanged the value to change
+ */
+fun updateNotation(
+    textFieldValue: TextFieldValue, text: String, kk: String,
+    notation: String, offset: Int, onValueChanged: (String) -> Unit
+): TextFieldValue {
+    Log.d(kk, "insertionPoint: ${textFieldValue.selection.start}")
+    val startIndex =
+        (textFieldValue.selection.start).coerceAtLeast(0)
+    val replaced = buildString {
+        append(text.substring(0, startIndex))
+        append(notation)
+        append(text.substring(textFieldValue.selection.start))
+    }
+    val insertionPoint = startIndex + notation.length - offset
+    Log.d(kk, "insertionPoint: $insertionPoint")
+    onValueChanged(replaced)
+    return TextFieldValue(replaced, TextRange(insertionPoint))
+}

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
@@ -54,39 +54,12 @@ class AddCardView(
         val helpForNotation = rememberSaveable { mutableStateOf(false) }
         fields = getSavableFields(fields)
         val type by navViewModel.type.collectAsStateWithLifecycle()
-        val selectedKB by addCardVM.selectedKB.collectAsStateWithLifecycle()
-        val showKB by addCardVM.showKatexKeyboard.collectAsStateWithLifecycle()
 
         Box(
             modifier = Modifier
                 .boxViewsModifier(getUIStyle.getColorScheme())
         ) {
             SymbolDocumentation(helpForNotation, getUIStyle)
-            if (type == Type.NOTATION && selectedKB != null) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .size(30.dp)
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onTap = { addCardVM.toggleKeyboard() },
-                                onLongPress = { addCardVM.resetOffset() }
-                            )
-                        }
-                ) {
-                    if (!showKB) {
-                        Icon(
-                            painterResource(R.drawable.twotone_keyboard),
-                            contentDescription = "Keyboard"
-                        )
-                    } else {
-                        Icon(
-                            painterResource(R.drawable.twotone_keyboard_hide),
-                            contentDescription = "Hide Keyboard"
-                        )
-                    }
-                }
-            }
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -171,7 +144,7 @@ class AddCardView(
                     )
 
                     Type.NOTATION -> AddNotationCard(
-                        addCardVM, deck,
+                        addCardVM, deck, navViewModel,
                         fields, getUIStyle, Modifier
                             .zIndex(2f)
                             .align(Alignment.Start)

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditNotationCard.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditNotationCard.kt
@@ -2,9 +2,6 @@ package com.belmontCrest.cardCrafter.views.cardViews.editCardViews
 
 import android.util.Log
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
@@ -18,195 +15,189 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.belmontCrest.cardCrafter.R
-import com.belmontCrest.cardCrafter.controller.viewModels.cardViewsModels.EditCardViewModel
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.model.uiModels.SelectedKeyboard
+import com.belmontCrest.cardCrafter.navigation.NavViewModel
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.uiFunctions.LatexKeyboard
 import com.belmontCrest.cardCrafter.uiFunctions.katex.KaTeXMenu
+import com.belmontCrest.cardCrafter.uiFunctions.katex.SelectedAnnotation
 import com.belmontCrest.cardCrafter.uiFunctions.showToastMessage
 
 @Composable
 fun EditNotationCard(
-    fields: Fields, vm: EditCardViewModel,
-    getUIStyle: GetUIStyle, modifier: Modifier
+    fields: Fields, vm: NavViewModel,
+    getUIStyle: GetUIStyle, onUpdate: () -> KaTeXMenu
 ) {
     var steps by rememberSaveable { mutableIntStateOf(fields.stringList.size) }
     val focusRequester = remember { FocusRequester() }
-    var selectedQSymbol by rememberSaveable { mutableStateOf<String?>(null) }
-    var selectedASymbol by rememberSaveable { mutableStateOf<String?>(null) }
-    var selectedSLSymbols = rememberSaveable { mutableListOf<String?>() }
-    val showKB by vm.showKatexKeyboard.collectAsStateWithLifecycle()
+    var selectedQSymbol by rememberSaveable {
+        mutableStateOf(KaTeXMenu(null, SelectedAnnotation.Idle))
+    }
+    var selectedASymbol by rememberSaveable {
+        mutableStateOf(KaTeXMenu(null, SelectedAnnotation.Idle))
+    }
+    var selectedSLSymbols = rememberSaveable {
+        MutableList<KaTeXMenu>(fields.stringList.size) {
+            KaTeXMenu(null, SelectedAnnotation.Idle)
+        }
+    }
     val selectedKB by vm.selectedKB.collectAsStateWithLifecycle()
-    var offset by remember { mutableStateOf(Offset.Zero) }
     val context = LocalContext.current
-    val resetOffset by vm.resetOffset.collectAsStateWithLifecycle()
-    LaunchedEffect(resetOffset) {
-        if (resetOffset) {
-            offset = Offset(0f, 0f)
-            vm.resetDone()
-        }
-    }
-    Box {
-        if (showKB) {
-            KaTeXMenu(
-                modifier.fillMaxSize(), offset, onDismiss = { vm.toggleKeyboard() },
-                onOffset = { offset += it }, getUIStyle
-            ) { symbol ->
-                when (val sel = selectedKB) {
-                    is SelectedKeyboard.Question -> {
-                        selectedQSymbol = symbol
-                    }
+    LaunchedEffect(onUpdate()) {
+        when (val sel = selectedKB) {
+            is SelectedKeyboard.Question -> {
+                selectedQSymbol = onUpdate()
+            }
 
-                    is SelectedKeyboard.Step -> {
-                        selectedSLSymbols[sel.index] = symbol
-                    }
+            is SelectedKeyboard.Step -> {
+                selectedSLSymbols[sel.index] = onUpdate()
+            }
 
-                    is SelectedKeyboard.Answer -> {
-                        selectedASymbol = symbol
-                    }
+            is SelectedKeyboard.Answer -> {
+                selectedASymbol = onUpdate()
+            }
 
-                    else -> {
-                        showToastMessage(context, "Please select a text field first.")
-                        /* No Keyboard, Do Nothing */
-                    }
+            else -> {
+                if (onUpdate().notation != null) {
+                    showToastMessage(context, "Please select a text field first.")
                 }
-
+                /* No Keyboard, Do Nothing */
             }
         }
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            LatexKeyboard(
-                value = fields.question.value,
-                onValueChanged = { fields.question.value = it },
-                labelStr = stringResource(R.string.question),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester)
-                    .onFocusChanged { focusState ->
-                        if (focusState.hasFocus) {
-                            vm.updateSelectedKB(SelectedKeyboard.Question)
-                            //lastSelectedKB = SelectedKeyboard.Question
-                            Log.d("AddCardVM", "Focused on Question")
-                        }
-                    }
-                    .focusable(),
-                focusRequester = focusRequester,
-                symbol = selectedQSymbol,
-                onSymbol = { selectedQSymbol = null }
-            )
-            if (steps == 0) {
-                Button(
-                    onClick = {
-                        fields.stringList.add(mutableStateOf(""))
-                        selectedSLSymbols.add(null)
-                        steps += 1
-                    }, modifier = Modifier
-                        .padding(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = getUIStyle.secondaryButtonColor(),
-                        contentColor = getUIStyle.buttonTextColor()
-                    ), enabled = true
-                ) {
-                    Text(
-                        text = "Add a step",
-                        textAlign = TextAlign.Center,
-                    )
+    }
+
+    LatexKeyboard(
+        value = fields.question.value,
+        onValueChanged = { fields.question.value = it },
+        labelStr = stringResource(R.string.question),
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester)
+            .onFocusChanged { focusState ->
+                if (focusState.hasFocus) {
+                    vm.updateSelectedKB(SelectedKeyboard.Question)
+                    //lastSelectedKB = SelectedKeyboard.Question
+                    Log.d("AddCardVM", "Focused on Question")
                 }
+            }
+            .focusable(),
+        focusRequester = focusRequester,
+        kt = selectedQSymbol,
+        onIdle = { selectedQSymbol = KaTeXMenu(null, SelectedAnnotation.Idle) }
+    )
+    if (steps == 0) {
+        Button(
+            onClick = {
+                fields.stringList.add(mutableStateOf(""))
+                selectedSLSymbols.add(KaTeXMenu(null, SelectedAnnotation.Idle))
+                steps += 1
+            }, modifier = Modifier
+                .padding(8.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = getUIStyle.secondaryButtonColor(),
+                contentColor = getUIStyle.buttonTextColor()
+            ), enabled = true
+        ) {
+            Text(
+                text = "Add a step",
+                textAlign = TextAlign.Center,
+            )
+        }
+    } else {
+        fields.stringList.forEachIndexed { index, string ->
+            val indexedModifier = if (index == 0) {
+                Modifier.padding(top = 5.dp, start = 0.5.dp, end = 0.5.dp, bottom = 1.dp)
             } else {
-                fields.stringList.forEachIndexed { index, string ->
-                    val indexedModifier = if (index == 0) {
-                        Modifier.padding(top = 5.dp, start = 0.5.dp, end = 0.5.dp, bottom = 1.dp)
-                    } else {
-                        Modifier.padding(1.dp)
-                    }
-                    LatexKeyboard(
-                        value = string.value,
-                        onValueChanged = { string.value = it },
-                        labelStr = "Step: ${index + 1}",
-                        modifier = indexedModifier
-                            .fillMaxWidth()
-                            .focusRequester(focusRequester)
-                            .onFocusChanged { focusState ->
-                                if (focusState.hasFocus) {
-                                    vm.updateSelectedKB(SelectedKeyboard.Step(index))
-                                    //lastSelectedKB = SelectedKeyboard.Step(index)
-                                    Log.d("AddCardVM", "Focused on Step #${index + 1}")
-                                }
-                            }
-                            .focusable(),
-                        focusRequester = focusRequester,
-                        symbol = selectedSLSymbols[index],
-                        onSymbol = { selectedSLSymbols[index] = null }
-                    )
-                }
-                Button(
-                    onClick = {
-                        fields.stringList.add(mutableStateOf(""))
-                        selectedSLSymbols.add(null)
-                        steps += 1
-                    }, modifier = Modifier
-                        .padding(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = getUIStyle.secondaryButtonColor(),
-                        contentColor = getUIStyle.buttonTextColor()
-                    ), enabled = true
-                ) {
-                    Text(
-                        text = "Add a step",
-                        textAlign = TextAlign.Center,
-                    )
-                }
-                Button(
-                    onClick = {
-                        if (steps > 0) {
-                            steps -= 1
-                            fields.stringList.removeAt(steps)
-                            selectedSLSymbols.removeAt(steps)
-                        }
-                    },
-                    modifier = Modifier.padding(top = 4.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = getUIStyle.secondaryButtonColor(),
-                        contentColor = getUIStyle.buttonTextColor()
-                    )
-                ) {
-                    Text("Remove Step")
-                }
+                Modifier.padding(1.dp)
             }
             LatexKeyboard(
-                value = fields.answer.value,
-                onValueChanged = { fields.answer.value = it },
-                labelStr = stringResource(R.string.answer),
-                modifier = Modifier
+                value = string.value,
+                onValueChanged = { string.value = it },
+                labelStr = "Step: ${index + 1}",
+                modifier = indexedModifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
                     .onFocusChanged { focusState ->
                         if (focusState.hasFocus) {
-                            vm.updateSelectedKB(SelectedKeyboard.Answer)
-                            //lastSelectedKB = SelectedKeyboard.Answer
-                            Log.d("AddCardVM", "Focused on Answer")
-                        } else {
-                            vm.resetSelectedKB()
-                            Log.d("AddCardVM", "Answer lost focus.")
+                            vm.updateSelectedKB(SelectedKeyboard.Step(index))
+                            //lastSelectedKB = SelectedKeyboard.Step(index)
+                            Log.d("AddCardVM", "Focused on Step #${index + 1}")
                         }
                     }
                     .focusable(),
                 focusRequester = focusRequester,
-                symbol = selectedASymbol,
-                onSymbol = { selectedASymbol = null }
+                kt = selectedSLSymbols[index],
+                onIdle = {
+                    selectedSLSymbols[index] =
+                        KaTeXMenu(null, SelectedAnnotation.Idle)
+                }
             )
         }
+        Button(
+            onClick = {
+                fields.stringList.add(mutableStateOf(""))
+                selectedSLSymbols.add(KaTeXMenu(null, SelectedAnnotation.Idle))
+                steps += 1
+            }, modifier = Modifier
+                .padding(8.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = getUIStyle.secondaryButtonColor(),
+                contentColor = getUIStyle.buttonTextColor()
+            ), enabled = true
+        ) {
+            Text(
+                text = "Add a step",
+                textAlign = TextAlign.Center,
+            )
+        }
+        Button(
+            onClick = {
+                if (steps > 0) {
+                    steps -= 1
+                    fields.stringList.removeAt(steps)
+                    selectedSLSymbols.removeAt(steps)
+                }
+            },
+            modifier = Modifier.padding(top = 4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = getUIStyle.secondaryButtonColor(),
+                contentColor = getUIStyle.buttonTextColor()
+            )
+        ) {
+            Text("Remove Step")
+        }
     }
+    LatexKeyboard(
+        value = fields.answer.value,
+        onValueChanged = { fields.answer.value = it },
+        labelStr = stringResource(R.string.answer),
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester)
+            .onFocusChanged { focusState ->
+                if (focusState.hasFocus) {
+                    vm.updateSelectedKB(SelectedKeyboard.Answer)
+                    //lastSelectedKB = SelectedKeyboard.Answer
+                    Log.d("AddCardVM", "Focused on Answer")
+                } else {
+                    vm.resetSelectedKB()
+                    Log.d("AddCardVM", "Answer lost focus.")
+                }
+            }
+            .focusable(),
+        focusRequester = focusRequester,
+        kt = selectedASymbol,
+        onIdle = { selectedASymbol = KaTeXMenu(null, SelectedAnnotation.Idle) }
+    )
 }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditingCardsList.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditingCardsList.kt
@@ -51,7 +51,7 @@ class EditCardsList(
         val sealedCardsList by editingCardListVM.sealedAllCTs.collectAsStateWithLifecycle()
         val searchQuery by editingCardListVM.searchQuery.collectAsStateWithLifecycle()
         val middleCard = rememberSaveable { mutableIntStateOf(0) }
-        var clicked by remember { mutableStateOf(false) }
+        var enabled by remember { mutableStateOf(true) }
 
         val filtered = sealedCardsList.allCTs.filter { ct ->
             if (searchQuery.isBlank()) {
@@ -105,13 +105,12 @@ class EditCardsList(
                 items(filtered.size) { index ->
                     Button(
                         onClick = {
-                            if (!clicked) {
+                                enabled = false
                                 fields.scrollPosition.value = index
                                 fields.isEditing.value = true
-                                clicked = true
                                 goToEditCard(filtered[index].getCardId())
-                            }
-                        },
+                                enabled = true
+                        }, enabled = enabled,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = getUIStyle.secondaryButtonColor(),
                             contentColor = getUIStyle.buttonTextColor()
@@ -120,10 +119,7 @@ class EditCardsList(
                             .fillMaxWidth()
                             .padding(8.dp)
                     ) {
-                        CardSelector(
-                            filtered,
-                            index
-                        )
+                        CardSelector(filtered, index)
                     }
                 }
             }


### PR DESCRIPTION
## Summary by Sourcery

Add accent support to the KaTeX symbol picker and refactor keyboard state management into a shared NavViewModel, unifying how notation and accents are inserted across all notation-based card views.

New Features:
- Add an 'Accents' section to the KaTeXMenu picker for inserting accent commands

Enhancements:
- Define a KaTeXMenu Parcelable and SelectedAnnotation sealed class to carry notation and annotation type
- Centralize show/hide, selection, and offset state for the KaTeX keyboard in NavViewModel
- Refactor LatexKeyboard to consume KaTeXMenu objects and use a shared updateNotation utility for both letters and accents
- Introduce a ToggleKeyBoard composable to attach a keyboard toggle button to notation card UIs
- Group Greek and other character lists into labeled variants for cleaner maintenance
- Automatically reset keyboard state on navigation changes in ModalContent and DeckNavHost

Chores:
- Clean up leftover SelectedKeyboard and keyboard state logic from individual card view models