### PR TITLE
Simple Due Cards View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ supabaseCredentials.txt
 # Derived & build
 DerivedData/
 build/
+DB_TEMP/

--- a/IOS/CardCrafter/CardCrafter.xcdatamodeld/CardCrafter.xcdatamodel/contents
+++ b/IOS/CardCrafter/CardCrafter.xcdatamodeld/CardCrafter.xcdatamodel/contents
@@ -16,6 +16,7 @@
         <attribute name="totalPasses" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="type" attributeType="String"/>
         <relationship name="deck" maxCount="1" deletionRule="Nullify" destinationEntity="Deck" inverseName="cards" inverseEntity="Deck"/>
+        <relationship name="saved" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SavedCard" inverseName="details" inverseEntity="SavedCard"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="cardIdentifier"/>
@@ -48,6 +49,16 @@
         <attribute name="choiceD" optional="YES" attributeType="String"/>
         <attribute name="correct" attributeType="String" minValueString="1" maxValueString="1"/>
         <attribute name="question" attributeType="String"/>
+    </entity>
+    <entity name="SavedCard" representedClassName="SavedCard" syncable="YES">
+        <attribute name="s_createdOn" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="s_nextReview" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="s_partOfList" attributeType="Boolean" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="s_passes" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="s_prevSuccess" attributeType="Boolean" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="s_reviewsLeft" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="s_totalPasses" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="details" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Card" inverseName="saved" inverseEntity="Card"/>
     </entity>
     <entity name="ThreeFieldCard" representedClassName="ThreeFieldCard" parentEntity="Card" syncable="YES">
         <attribute name="answer" attributeType="String"/>

--- a/IOS/CardCrafter/ContentView.swift
+++ b/IOS/CardCrafter/ContentView.swift
@@ -55,11 +55,18 @@ struct ContentView: View {
             .navigationDestination(for: Route.self) { route in
                 switch route {
                 case .deckDetail(let deck):
-                    DeckDetailView(deck: deck, path: $path)
+                DeckDetailView(deck: deck, path: $path)
                 case .editDeck(let deck):
                     EditDeckView(deck: deck)
                 case .editCards(let deck):
                     CardListView(deck: deck)
+                }
+            }
+            .onAppear {
+                do {
+                    try resetCardLefts()
+                } catch {
+                    print("resetCardLefts failed:", error)
                 }
             }
         }
@@ -68,6 +75,58 @@ struct ContentView: View {
     private func deleteDecks(offsets: IndexSet) {
         offsets.map { decks[$0] }.forEach(viewContext.delete)
         try? viewContext.save()
+    }
+    
+    private func resetCardLefts(
+        currentTime: Date = .init(),
+        startOfDay: Date = Calendar.current.startOfDay(for: .init())
+    ) throws {
+        // 1. Fetch all Decks that need resetting
+        let deckReq: NSFetchRequest<Deck> = Deck.fetchRequest()
+        deckReq.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "d_nextReview <= %@", currentTime as NSDate),
+            NSPredicate(format: "lastUpdated != %@", startOfDay as NSDate),
+            // NOT EXISTS a card in this deck with partOfList==true AND lastUpdated==startOfDay
+            NSPredicate(format: "NOT (ANY cards.partOfList == true AND lastUpdated == %@)", startOfDay as NSDate)
+        ])
+        let decks = try viewContext.fetch(deckReq)
+
+        for deck in decks {
+            // Count of due cards in this deck
+            let dueCount = deck.cards
+                .compactMap { $0 as? Card }
+                .filter { $0.c_nextReview <= currentTime }
+                .count
+            // Get the most Recent SavedCard with the Card itself
+            let recentByCard: [(card: Card, saved: SavedCard)] = (deck.cards as? Set<Card> ?? [])
+                .compactMap { card in
+                    guard let rec = card.savedRecords.first else { return nil }
+                    return (card, rec)
+                }
+            // For each Pair, update the Card based on the most recent SavedCard
+            for pair in recentByCard {
+                let card = pair.card
+                let saved = pair.saved
+                card.c_nextReview = saved.s_nextReview
+                card.reviewsLeft = saved.s_reviewsLeft
+                card.passes = saved.s_passes
+                card.totalPasses = saved.s_totalPasses
+                card.partOfList = saved.s_nextReview <= Date()
+                card.prevSuccess = saved.s_prevSuccess
+            }
+            // Get all SavedCards and then delete them.
+            let savedCards: [SavedCard] = (deck.cards as? Set<Card> ?? [])
+                .flatMap { $0.savedRecords }
+            
+            for card in savedCards { viewContext.delete(card) }
+            
+            // Clamp between 0 and deck.cardAmount
+            let maxAllowed = Int(deck.cardAmount)
+            deck.cardsLeft = Int16(min(dueCount, maxAllowed))
+            deck.cardsDone = 0
+            deck.lastUpdated = startOfDay
+        }
+        try viewContext.save()
     }
 }
 

--- a/IOS/CardCrafter/DB/BasicCard+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/BasicCard+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  BasicCard+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/Card+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/Card+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Card+CoreDataClass.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/Card+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/Card+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Card+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 
@@ -27,9 +27,12 @@ extension Card {
     @NSManaged public var totalPasses: Int32
     @NSManaged public var type: String
     @NSManaged public var deck: Deck
+    @NSManaged public var saved: NSSet
 
 }
 
 extension Card : Identifiable {
-
+    var savedRecords: [SavedCard] {
+        (saved as? Set<SavedCard> ?? []).sorted { $0.s_createdOn > $1.s_createdOn }
+    }
 }

--- a/IOS/CardCrafter/DB/Deck+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/Deck+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Deck+CoreDataClass.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/Deck+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/Deck+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Deck+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 
@@ -49,5 +49,16 @@ extension Deck {
 }
 
 extension Deck : Identifiable {
-
+    var dueCards: [Card] {
+           Array(
+               (cards as? Set<Card> ?? [])
+                   .filter { $0.c_nextReview <= Date() }
+                   .sorted { (a: Card, b: Card) -> Bool in
+                       if a.c_nextReview != b.c_nextReview { return a.c_nextReview < b.c_nextReview }
+                       if a.partOfList   != b.partOfList   { return a.partOfList && !b.partOfList }
+                       return a.reviewsLeft > b.reviewsLeft
+                   }
+                   .prefix(Int(cardsLeft))
+           )
+       }
 }

--- a/IOS/CardCrafter/DB/HintCard+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/HintCard+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  HintCard+CoreDataClass.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/HintCard+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/HintCard+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  HintCard+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/MultiChoiceCard+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/MultiChoiceCard+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  MultiChoiceCard+CoreDataClass.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/MultiChoiceCard+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/MultiChoiceCard+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  MultiChoiceCard+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 
@@ -16,11 +16,11 @@ extension MultiChoiceCard {
         return NSFetchRequest<MultiChoiceCard>(entityName: "MultiChoiceCard")
     }
 
-    @NSManaged public var question: String
     @NSManaged public var choiceA: String
     @NSManaged public var choiceB: String
     @NSManaged public var choiceC: String?
     @NSManaged public var choiceD: String?
     @NSManaged public var correct: String
+    @NSManaged public var question: String
 
 }

--- a/IOS/CardCrafter/DB/SavedCard+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/SavedCard+CoreDataClass.swift
@@ -1,5 +1,5 @@
 //
-//  BasicCard+CoreDataClass.swift
+//  SavedCard+CoreDataClass.swift
 //  CardCrafter
 //
 //  Created by Assykilla on 8/2/25.
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 
-@objc(BasicCard)
-public class BasicCard: Card {
+@objc(SavedCard)
+public class SavedCard: NSManagedObject {
 
 }

--- a/IOS/CardCrafter/DB/SavedCard+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/SavedCard+CoreDataProperties.swift
@@ -1,0 +1,32 @@
+//
+//  SavedCard+CoreDataProperties.swift
+//  CardCrafter
+//
+//  Created by Assykilla on 8/2/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension SavedCard {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SavedCard> {
+        return NSFetchRequest<SavedCard>(entityName: "SavedCard")
+    }
+
+    @NSManaged public var s_reviewsLeft: Int16
+    @NSManaged public var s_nextReview: Date
+    @NSManaged public var s_passes: Int32
+    @NSManaged public var s_totalPasses: Int32
+    @NSManaged public var s_prevSuccess: Bool
+    @NSManaged public var s_partOfList: Bool
+    @NSManaged public var s_createdOn: Date
+    @NSManaged public var details: Card
+
+}
+
+extension SavedCard : Identifiable {
+
+}

--- a/IOS/CardCrafter/DB/ThreeFieldCard+CoreDataClass.swift
+++ b/IOS/CardCrafter/DB/ThreeFieldCard+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  ThreeFieldCard+CoreDataClass.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/DB/ThreeFieldCard+CoreDataProperties.swift
+++ b/IOS/CardCrafter/DB/ThreeFieldCard+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  ThreeFieldCard+CoreDataProperties.swift
 //  CardCrafter
 //
-//  Created by Assykilla on 7/30/25.
+//  Created by Assykilla on 8/2/25.
 //
 //
 

--- a/IOS/CardCrafter/Views/CardDeckView.swift
+++ b/IOS/CardCrafter/Views/CardDeckView.swift
@@ -1,0 +1,237 @@
+//
+//  CardDeckView.swift
+//  CardCrafter
+//
+//  Created by Assykilla on 7/31/25.
+//
+
+import SwiftUI
+import CoreData
+struct CardDeckView : View {
+    @ObservedObject var deck : Deck
+    @Binding var index: Int
+    @Environment(\.managedObjectContext) private var viewContext
+    /** Sorted by the most recent on top (first) */
+    @FetchRequest(
+        entity: SavedCard.entity(),
+        sortDescriptors: [NSSortDescriptor(key: "s_createdOn", ascending: false)]
+    )
+    private var savedCards: FetchedResults<SavedCard>
+    @State private var showError = false
+    @State private var enabled = true
+    
+    var body: some View {
+        var canRedoPrevious: Bool {
+            // 1) must be enabled
+            guard enabled else { return false }
+            // 2) must have a “previous” index in bounds
+            guard index > 0, deck.dueCards.indices.contains(index - 1) else { return false }
+            // 3) and that previous card must have at least one savedRecord
+            return !deck.dueCards[index - 1].savedRecords.isEmpty
+        }
+        VStack {
+            if deck.dueCards.isEmpty {
+                Text("No due cards")
+                    .foregroundColor(.secondary)
+                    .italic()
+            } else {
+                let currentCard = deck.dueCards[index]
+                if let basic = currentCard as? BasicCard {
+                    Text("\(basic.question)")
+                } else if let three = currentCard as? ThreeFieldCard {
+                    Text("\(three.question)")
+                } else if let hint = currentCard as? HintCard {
+                    Text("\(hint.question)")
+                } else if let multi = currentCard as? MultiChoiceCard {
+                    Text("\(multi.question)")
+                } else {
+                    Text("Error: Unknown Card Type Stored")
+                }
+                let good = Int(Double(deck.dueCards[index].passes + 1) * deck.goodMultiplier)
+                let hard = if (deck.dueCards[index].passes > 0){
+                    Int(Double(deck.dueCards[index].passes + 1) * deck.badMultiplier)
+                } else {
+                    Int(Double(deck.dueCards[index].passes) * deck.badMultiplier)
+                }
+                HStack {
+                    VStack {
+                        Button(action: {
+                            enabled = false
+                            let result = updateCard(isSuccess: false, again: false)
+                            if(!result) { showError = true }
+                            enabled = true
+                        }) {
+                            Text("Again")
+                        }.disabled(!enabled)
+                        Text("---")
+                    }
+                    VStack {
+                        Button(action: {
+                            enabled = false
+                            let result = updateCard(isSuccess: false, again: false)
+                            if(result){
+                                let newIndex = index + 1
+                                if deck.dueCards.indices.contains(newIndex) {
+                                    index = newIndex
+                                } else {
+                                    index = 0
+                                }
+                            } else { showError = true }
+                            enabled = true
+                        }) {
+                            Text("Hard")
+                        }.disabled(!enabled)
+                        
+                        if currentCard.reviewsLeft == 1 {
+                            Text("\(hard) days")
+                        } else {
+                            Text("\(currentCard.reviewsLeft) reviews left")
+                        }
+                    }
+                    VStack{
+                        Button(action: {
+                            enabled = false
+                            let result = updateCard(isSuccess: true, again: false)
+                            if(result){
+                                let newIndex = index + 1
+                                if deck.dueCards.indices.contains(newIndex) {
+                                    index = newIndex
+                                } else {
+                                    index = 0
+                                }
+                            } else { showError = true }
+                            enabled = true
+                        }) {
+                            Text("Good")
+                        }.disabled(!enabled)
+                        if currentCard.reviewsLeft == 1 {
+                            Text("\(good) days")
+                        } else {
+                            Text("\(currentCard.reviewsLeft - 1) reviews left")
+                        }
+                    }
+                    
+                }.alert("Failed to update card", isPresented: $showError) {
+                    Button("OK", role: .cancel) { }
+                }
+            }
+        }.toolbar {
+#if os(iOS)
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button{
+                    enabled = false
+                    let result = redoCard()
+                    if(result){ index -= 1  } else { showError = true }
+                    enabled = true
+                } label: {
+                    Label("Redo", systemImage: "arrowshape.turn.up.backward.fill")
+                }.disabled(!canRedoPrevious)
+            }
+#else
+            ToolbarItem {
+                Button{
+                    enabled = false
+                    let result = redoCard()
+                    if(result){ index -= 1 } else { showError = true }
+                    enabled = true
+                } label: {
+                    Label("Redo", systemImage: "arrowshape.turn.up.backward.fill")
+                }.disabled(!canRedoPrevious)
+            }
+#endif
+        }
+    }
+    
+    private func updateCard(isSuccess: Bool, again: Bool) -> Bool {
+        do {
+            guard deck.dueCards.indices.contains(index) else { return false }
+            let temp = deck.dueCards[index]
+            let prevSuccess = temp.prevSuccess
+            
+            if(temp.reviewsLeft <= 1) {
+                if(isSuccess) {
+                    temp.passes += 1
+                    temp.prevSuccess = true
+                    temp.reviewsLeft = deck.reviewAmount
+                } else {
+                    if (!again) {
+                        temp.reviewsLeft = deck.reviewAmount
+                    }
+                    temp.prevSuccess = false
+                }
+                temp.c_nextReview = timeCalculator(passes: Int(temp.passes), isSuccess: isSuccess)
+                if (!isSuccess && !prevSuccess && temp.passes > 0) {
+                    temp.passes -= 1
+                }
+            } else {
+                /** When the user reviews a card x amount of times
+                 *  Default value is 1
+                 */
+                if (isSuccess) {
+                    temp.reviewsLeft -= 1
+                }
+            }
+            temp.totalPasses += 1
+            temp.partOfList = true
+            let saved = SavedCard(context: viewContext)
+            saved.s_createdOn = Date()
+            saved.s_totalPasses = temp.totalPasses
+            saved.s_passes = temp.passes
+            saved.s_partOfList = temp.partOfList
+            saved.s_nextReview = temp.c_nextReview
+            saved.s_prevSuccess = temp.prevSuccess
+            saved.s_reviewsLeft = temp.reviewsLeft
+            saved.details = temp
+            try viewContext.save()
+            return true
+        } catch {
+            viewContext.rollback()
+            return false
+        }
+    }
+    
+    private func timeCalculator(passes: Int, isSuccess: Bool) -> Date {
+        let now = Date()
+        let multiplier = calculateReviewMultiplier(passes: passes,isSuccess: isSuccess)
+        let daysToAdd = Int(Double(passes) * multiplier)
+        return Calendar.current.date(
+            byAdding: .day,
+            value: daysToAdd,
+            to: now
+        )!
+    }
+    
+    private func calculateReviewMultiplier(passes: Int,isSuccess: Bool) -> Double {
+        let baseMultiplier: Double
+        switch passes {
+        case 1:
+            baseMultiplier = 1.0
+        case 2...:
+            baseMultiplier = deck.badMultiplier
+        default:
+            baseMultiplier = 0.0
+        }
+        return isSuccess ? deck.goodMultiplier : baseMultiplier
+    }
+    private func redoCard() -> Bool {
+        do {
+            guard !savedCards.isEmpty else { return false }
+            guard let record = savedCards.first else { return false }
+            /** Where record.details is just Card */
+            let temp = record.details
+            temp.c_nextReview = record.s_nextReview
+            temp.reviewsLeft = record.s_reviewsLeft
+            temp.passes = record.s_passes
+            temp.totalPasses = record.s_totalPasses
+            temp.prevSuccess = record.s_prevSuccess
+            temp.partOfList = record.s_partOfList
+            /** Delete the record, pushing it out of the list so you can redo again to the previous (if there is one)*/
+            viewContext.delete(record)
+            try viewContext.save()
+            return true
+        } catch {
+            viewContext.rollback()
+            return false
+        }
+    }
+}

--- a/IOS/CardCrafter/Views/DeckDetailView.swift
+++ b/IOS/CardCrafter/Views/DeckDetailView.swift
@@ -13,6 +13,7 @@ import CoreData
 struct DeckDetailView: View {
     @ObservedObject var deck: Deck
     @Binding var path: [Route]
+    @State private var index: Int = 0
     
     var body: some View {
         VStack(spacing: 20) {
@@ -23,6 +24,9 @@ struct DeckDetailView: View {
             Text("Review amount: \(deck.reviewAmount)")
             NavigationLink(destination: AddCardView(deck: deck)) {
                 Text("Add New Card")
+            }
+            NavigationLink(destination: CardDeckView(deck: deck, index: $index)) {
+                Text("Start Deck")
             }
         }.toolbar {
 #if os(iOS)
@@ -57,7 +61,6 @@ struct DeckDetailView: View {
         }
         .navigationTitle("\(deck.d_name)")
         .padding()
-        
     }
 }
 

--- a/IOS/CardCrafter/Views/EditDeckView.swift
+++ b/IOS/CardCrafter/Views/EditDeckView.swift
@@ -17,7 +17,7 @@ struct EditDeckView: View {
     @State private var badMultiplier: Double
     @State private var errorMessage: String?
     @Environment(\.managedObjectContext) private var viewContext
-    @Environment(\.presentationMode)    private var presentationMode
+    @Environment(\.presentationMode) private var presentationMode
     
     init(deck: Deck) {
         self.deck = deck


### PR DESCRIPTION
Added the logic when traversing DueCards logic view (and upgraded it)
TODO - We now need to redo the Android version of redoing cards, Implement front and back of cards.

## Summary by Sourcery

Implement a due cards review flow including a new CardDeckView with review actions, persistent review history via a SavedCard entity, start deck navigation, and automatic reset logic for due cards on app launch.

New Features:
- Add CardDeckView for reviewing due cards with "Again", "Hard", and "Good" actions
- Introduce SavedCard Core Data entity to persist review state and support redo functionality
- Add "Start Deck" button in DeckDetailView to launch the review flow
- Invoke resetCardLefts on app launch to refresh due card counts and next review dates

Enhancements:
- Add dueCards computed property to Deck for filtering and sorting due cards
- Expose savedRecords sorted by creation date in Card to access review history